### PR TITLE
Permit woff1:#anchor syntax in any test

### DIFF
--- a/generators/AuthoringToolTestCaseGenerator.py
+++ b/generators/AuthoringToolTestCaseGenerator.py
@@ -27,15 +27,8 @@ from fontTools.ttLib.sfnt import sfntDirectorySize, sfntDirectoryEntrySize
 from testCaseGeneratorLib.defaultData import defaultSFNTTestData
 from testCaseGeneratorLib.sfnt import packSFNT
 from testCaseGeneratorLib.paths import resourcesDirectory, authoringToolDirectory, authoringToolTestDirectory, authoringToolResourcesDirectory
-from testCaseGeneratorLib.html import generateAuthoringToolIndexHTML
+from testCaseGeneratorLib.html import generateAuthoringToolIndexHTML, expandSpecLinks
 from testCaseGeneratorLib.utilities import padData, calcPaddingLength, calcTableChecksum
-
-# ------------------------
-# Specification URL
-# This is used frequently.
-# ------------------------
-
-specificationURL = "http://dev.w3.org/webfonts/WOFF2/spec/"
 
 # ------------------
 # Directory Creation
@@ -103,10 +96,10 @@ that is bitwise identical to the original SFNT.
 groupDefinitions = [
     # identifier, title, spec section, category note
     ("validsfnt", "Valid SFNTs", None, validNote),
-    ("invalidsfnt", "Invalid SFNT Tests", specificationURL+"#conform-incorrect-reject", invalidSFNTNote),
-    ("tabledata", "SFNT Table Data Tests", specificationURL+"#DataTables", tableDataNote),
-    ("tabledirectory", "SFNT Table Directory Tests", specificationURL+"#DataTables", tableDirectoryNote),
-    ("bitwiseidentical", "SFNT Bitwise Identical Tests", specificationURL+"#conform-identical", bitwiseNote),
+    ("invalidsfnt", "Invalid SFNT Tests", expandSpecLinks("#conform-incorrect-reject"), invalidSFNTNote),
+    ("tabledata", "SFNT Table Data Tests", expandSpecLinks("#DataTables"), tableDataNote),
+    ("tabledirectory", "SFNT Table Directory Tests", expandSpecLinks("#DataTables"), tableDirectoryNote),
+    ("bitwiseidentical", "SFNT Bitwise Identical Tests", expandSpecLinks("#conform-identical"), bitwiseNote),
 ]
 
 testRegistry = {}
@@ -161,10 +154,7 @@ def writeTest(identifier, title, description, data, specLink=None, credits=[], s
     registeredTitles.add(title)
     registeredDescriptions.add(description)
 
-    if specLink is None:
-        specLink = specificationURL
-    else:
-        specLink = specificationURL + specLink
+    specLink = expandSpecLinks(specLink)
 
     # generate the SFNT
     sfntPath = os.path.join(authoringToolTestDirectory, identifier)

--- a/generators/FormatTestCaseGenerator.py
+++ b/generators/FormatTestCaseGenerator.py
@@ -27,17 +27,9 @@ from fontTools.misc import sstruct
 from testCaseGeneratorLib.woff import packTestHeader, packTestDirectory, packTestMetadata, packTestPrivateData
 from testCaseGeneratorLib.defaultData import defaultTestData, testDataWOFFMetadata, testDataWOFFPrivateData
 from testCaseGeneratorLib.paths import resourcesDirectory, formatDirectory, formatTestDirectory, formatResourcesDirectory, sfntTTFCompositeSourcePath
-from testCaseGeneratorLib.html import generateFormatIndexHTML
+from testCaseGeneratorLib.html import generateFormatIndexHTML, expandSpecLinks
 from testCaseGeneratorLib import sharedCases
 from testCaseGeneratorLib.sharedCases import *
-
-# ------------------------
-# Specification URL
-# This is used frequently.
-# ------------------------
-
-specificationURL = "http://dev.w3.org/webfonts/WOFF2/spec/"
-woff1SpecificationURL = "http://www.w3.org/TR/WOFF/"
 
 # ------------------
 # Directory Creation
@@ -72,12 +64,12 @@ shutil.copy(os.path.join(resourcesDirectory, "index.css"), destPath)
 groupDefinitions = [
     # identifier, title, spec section
     ("valid", "Valid WOFFs", None),
-    ("header", "WOFF Header Tests", specificationURL+"#woff20Header"),
-    ("blocks", "WOFF Data Block Tests", specificationURL+"#FileStructure"),
-    ("directory", "WOFF Table Directory Tests", specificationURL+"#table_dir_format"),
-    ("tabledata", "WOFF Table Data Tests", specificationURL+"#DataTables"),
-    ("metadata", "WOFF Metadata Tests", specificationURL+"#Metadata"),
-    ("privatedata", "WOFF Private Data Tests", specificationURL+"#Private")
+    ("header", "WOFF Header Tests", expandSpecLinks("#woff20Header")),
+    ("blocks", "WOFF Data Block Tests", expandSpecLinks("#FileStructure")),
+    ("directory", "WOFF Table Directory Tests", expandSpecLinks("#table_dir_format")),
+    ("tabledata", "WOFF Table Data Tests", expandSpecLinks("#DataTables")),
+    ("metadata", "WOFF Metadata Tests", expandSpecLinks("#Metadata")),
+    ("privatedata", "WOFF Private Data Tests", expandSpecLinks("#Private"))
 ]
 
 testRegistry = {}
@@ -131,16 +123,7 @@ def writeTest(identifier, title, description, data, specLink=None, credits=[], v
     registeredTitles.add(title)
     registeredDescriptions.add(description)
 
-    if specLink is None:
-        specLink = ""
-    links = []
-    for link in specLink.split(" "):
-        if link.startswith("woff1:"):
-            link = woff1SpecificationURL + link[6:]
-        else:
-            link = specificationURL + link
-        links.append(link)
-    specLink = " ".join(links)
+    specLink = expandSpecLinks(specLink)
 
     # generate the WOFF
     woffPath = os.path.join(formatTestDirectory, identifier) + ".woff2"

--- a/generators/UserAgentTestCaseGenerator.py
+++ b/generators/UserAgentTestCaseGenerator.py
@@ -30,17 +30,10 @@ import shutil
 import glob
 from testCaseGeneratorLib.woff import packTestHeader, packTestDirectory, packTestMetadata, packTestPrivateData
 from testCaseGeneratorLib.defaultData import defaultTestData, testDataWOFFMetadata, testDataWOFFPrivateData
-from testCaseGeneratorLib.html import generateSFNTDisplayTestHTML, generateSFNTDisplayRefHTML, generateSFNTDisplayIndexHTML
+from testCaseGeneratorLib.html import generateSFNTDisplayTestHTML, generateSFNTDisplayRefHTML, generateSFNTDisplayIndexHTML, expandSpecLinks
 from testCaseGeneratorLib.paths import resourcesDirectory, userAgentDirectory, userAgentTestDirectory, userAgentTestResourcesDirectory, userAgentFontsToInstallDirectory, sfntTTFCompositeSourcePath
 from testCaseGeneratorLib import sharedCases
 from testCaseGeneratorLib.sharedCases import *
-
-# ------------------------
-# Specification URL
-# This is used frequently.
-# ------------------------
-
-specificationURL = "http://dev.w3.org/webfonts/WOFF2/spec/"
 
 # ------------------
 # Directory Creation
@@ -104,16 +97,16 @@ shutil.copy(os.path.join(resourcesDirectory, "index.css"), destPath)
 
 groupDefinitions = [
     # identifier, title, spec section
-    ("valid", "Valid WOFFs", specificationURL+"#FileStructure"),
-    ("datatypes", "Data types", specificationURL+"#DataTypes"),
-    ("header", "WOFF Header Tests", specificationURL+"#woff20Header"),
-    ("blocks", "WOFF Data Block Tests", specificationURL+"#FileStructure"),
-    ("directory", "WOFF Table Directory Tests", specificationURL+"#table_dir_format"),
-    ("tabledata", "WOFF Table Data Tests", specificationURL+"#DataTables"),
-    ("metadata", "WOFF Metadata Tests", specificationURL+"#Metadata"),
-    ("privatedata", "WOFF Private Data Tests", specificationURL+"#Private"),
-    ("metadatadisplay", "WOFF Metadata Display Tests", specificationURL+"#Metadata"),
-    ("available", "Availability", specificationURL+"#conform-css3font-available"),
+    ("valid", "Valid WOFFs", expandSpecLinks("#FileStructure")),
+    ("datatypes", "Data types", expandSpecLinks("#DataTypes")),
+    ("header", "WOFF Header Tests", expandSpecLinks("#woff20Header")),
+    ("blocks", "WOFF Data Block Tests", expandSpecLinks("#FileStructure")),
+    ("directory", "WOFF Table Directory Tests", expandSpecLinks("#table_dir_format")),
+    ("tabledata", "WOFF Table Data Tests", expandSpecLinks("#DataTables")),
+    ("metadata", "WOFF Metadata Tests", expandSpecLinks("#Metadata")),
+    ("privatedata", "WOFF Private Data Tests", expandSpecLinks("#Private")),
+    ("metadatadisplay", "WOFF Metadata Display Tests", expandSpecLinks("#Metadata")),
+    ("available", "Availability", expandSpecLinks("#conform-css3font-available")),
 ]
 
 testRegistry = {}
@@ -197,11 +190,9 @@ def writeFileStructureTest(identifier, flavor="CFF",
     registeredTitles.add(title)
     registeredAssertions.add(assertion)
 
-    if sfntDisplaySpecLink is None:
-        sfntDisplaySpecLink = ""
-    sfntDisplaySpecLink = [specificationURL + i for i in sfntDisplaySpecLink.split(" ")]
+    sfntDisplaySpecLink = expandSpecLinks(sfntDisplaySpecLink).split(" ")
     if metadataDisplaySpecLink is not None:
-        metadataDisplaySpecLink = specificationURL + metadataDisplaySpecLink
+        metadataDisplaySpecLink = expandSpecLinks(metadataDisplaySpecLink)
     flags = list(flags)
     flags += ["font"] # fonts must be installed for all of these tests
 
@@ -286,11 +277,11 @@ def writeMetadataSchemaValidityTest(identifier,
     # pass to the more verbose function
     if metadataDisplaySpecLink is None:
         if not metadataIsValid:
-            metadataDisplaySpecLink = "#conform-invalid-mustignore"
+            metadataDisplaySpecLink = "woff1:#conform-invalid-mustignore"
         else:
             metadataDisplaySpecLink = "#Metadata"
     if sfntDisplaySpecLink is None:
-        sfntDisplaySpecLink = "#conform-metadata-noeffect"
+        sfntDisplaySpecLink = "woff1:#conform-metadata-noeffect"
     kwargs = dict(
         title=title,
         assertion=assertion,
@@ -2878,7 +2869,7 @@ testRegistry[tag].append(
         title=title,
         assertion=assertion,
         sfntExpectation=True,
-        sfntURL=[specificationURL+"#General", specificationURL+"#conform-css3font-available"],
+        sfntURL=[expandSpecLinks("#General"), expandSpecLinks("#conform-css3font-available")],
         metadataExpectation=None,
         metadataURL=None,
         credits=[dict(title="Chris Lilley", role="author", link="http://www.w3.org/People")],

--- a/generators/testCaseGeneratorLib/html.py
+++ b/generators/testCaseGeneratorLib/html.py
@@ -5,6 +5,14 @@ Test case HTML generator.
 import os
 import cgi
 
+# ------------------------
+# Specification URLs
+# This is used frequently.
+# ------------------------
+
+specificationURL = "http://dev.w3.org/webfonts/WOFF2/spec/"
+woff1SpecificationURL = "http://www.w3.org/TR/WOFF/"
+
 # ------------------
 # SFNT Display Tests
 # ------------------
@@ -497,3 +505,26 @@ def generateAuthoringToolIndexHTML(directory=None, testCases=[], note=None):
     f = open(path, "wb")
     f.write(html)
     f.close()
+
+
+def expandSpecLinks(links):
+    """
+    This function expands anchor-only references to fully qualified spec links.
+    #name expands to <woff2specurl>#name. woff1:#name expands to
+    <woff1specurl>#name.
+
+    links: 0..N space-separated #anchor references
+    """
+    if links is None or len(links) == 0:
+        links = ""
+
+    specLinks = []
+    for link in links.split(" "):
+        if link.startswith("woff1:"):
+            link = woff1SpecificationURL + link[6:]
+        else:
+            link = specificationURL + link
+
+        specLinks.append(link)
+
+    return " ".join(specLinks)


### PR DESCRIPTION
Migrated link expansion function to shared library and used in all three test suites
