### PR TITLE
Remove note to install fonts

### DIFF
--- a/generators/resources/index.css
+++ b/generators/resources/index.css
@@ -29,17 +29,6 @@ h1 {
 	padding: 0px 0px 20px 0px;
 }
 
-p.installFontsNote {
-	font-weight: bold;
-	color: white;
-	background-color: red;
-	padding: 5px 10px 5px 10px;
-}
-
-p.installFontsNote a {
-	color: white;
-}
-
 .mainNote {
 	margin: 0px;
 	padding: 15px 0px 15px 0px;

--- a/generators/testCaseGeneratorLib/html.py
+++ b/generators/testCaseGeneratorLib/html.py
@@ -258,8 +258,7 @@ def generateSFNTDisplayIndexHTML(directory=None, testCases=[]):
         "\t\t</style>",
         "\t</head>",
         "\t<body>",
-        "\t\t<h1>WOFF 2.0: User Agent Test Suite (%d tests)</h1>" % testCount,
-        "\t\t<p class=\"installFontsNote\">All of these tests require special fonts to be installed. The fonts can be obtained <a href=\"../../FontsToInstall\">here</a>.</p>"
+        "\t\t<h1>WOFF 2.0: User Agent Test Suite (%d tests)</h1>" % testCount
     ]
     # add the test groups
     for group in testCases:


### PR DESCRIPTION
This was only used by the UserAgent test suite but it is replaced by WOFF fonts.

@khaledhosny Can you please review this?